### PR TITLE
Use logging._nameToLevel but fallback to _levelNames if unavailable

### DIFF
--- a/request_id/__init__.py
+++ b/request_id/__init__.py
@@ -18,7 +18,13 @@ def make_filter(
     **kw
 ):
     if isinstance(logging_level, str):
-        logging_level = logging._levelNames[logging_level]
+        try:
+            level_names = logging._nameToLevel
+        except AttributeError:
+            level_names = logging._levelNames
+        if logging_level not in level_names:
+            raise ValueError('Unknown logging level: %s' % logging_level)
+        logging_level = level_names[logging_level]
 
     if exclude_prefixes is not None:
         exclude_prefixes = aslist(exclude_prefixes)


### PR DESCRIPTION
Python 3.4 split logging._levelNames into _nameToLevel and _levelToName.
Passing a logging_level argument to this middleware fails on Python >=
3.4 because logging._levelNames no longer exists. Middleware should try
the newer logging._nameToLevel first and fallback to _levelNames only
when it is not available.